### PR TITLE
Add "addressable" index

### DIFF
--- a/src/database/migrations/2020_12_14_113555_add_addressable_index.php
+++ b/src/database/migrations/2020_12_14_113555_add_addressable_index.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAddressableIndex extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('addresses', function (Blueprint $table) {
+            $table->index(['addressable_type', 'addressable_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('addresses', function (Blueprint $table) {
+            $table->dropIndex(['addressable_type', 'addressable_id']);
+        });
+    }
+}


### PR DESCRIPTION
Although a relationship would normally be automatically indexed under Laravel/MySQL, a morphable relationship isn't backed by a real MySQL FK and as such no index existed on these columns.

Adding this sped up some search queries over 100x.