### PR TITLE
Add strict flag to configuration (fixes #5).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 composer.lock
 .idea
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Note that by default, you require a Google Maps API key in order to provide
 address geocoding and distance calculations. If you do not wish to use geocoding,
 this can be disabled in the configuration.
 
+### Strict geocoding
+
+By default, geocoding is configured as "lenient"; if, for example, the name of a real city is given
+but the postcode and street address refer to a nonexistent place, it will geocode as the center of
+that city.
+
+Set the `geocoding.strict` flag to `true` in the configuration file to instead fail to geocode in
+this scenario.
+
 ## Usage
 
 Assign the `HasAddresses` trait to the model you wish to have associated addresses.

--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -92,9 +92,13 @@ class Address extends Model
             return;
         }
 
-        $latLng = GoogleMaps::instance()
-            ->allowPartialMatches()
-            ->geocode($this->human_readable);
+        $googleMaps = GoogleMaps::instance();
+
+        if (!config('addresses.geocoding.strict')) {
+            $googleMaps = $googleMaps->allowPartialMatches();
+        }
+
+        $latLng = $googleMaps->geocode($this->human_readable);
 
         if ($latLng) {
             $this->latitude = $latLng->lat;

--- a/src/config/addresses.php
+++ b/src/config/addresses.php
@@ -9,6 +9,7 @@ return [
         'enabled' => true,
         'google-maps' => [
             'api-key' => env('GEOCODING_GOOGLE_MAPS_API_KEY'),
-        ]
+        ],
+        'strict' => false,
     ]
 ];


### PR DESCRIPTION
### Linked Stories.
- [#5](https://github.com/DivineOmega/laravel-addresses/issues/5)

### Overview.
- Adds a `strict` flag to configuration which when set requires exact matches for addresses.
- Added to documentation.
- Checked that when the flag is missing (e.g. after updating the package with exported config) it continues to run in lenient mode.

#### Bug Fixes
- .gitignore update to prevent macOS files being included.