### PR TITLE
Add support for Laravel 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Features:
 * Conversion of ISO country code to country name
 * Ability to store meta data about addresses - e.g. `['type' => 'delivery', 'name' => 'home_address']`
 
+## Compatibility
+
+This package supports Laravel versions 5.6 through 10.
+
 ## Installation
 
 To install Laravel Addresses, just run the following Composer command.

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": ">=7.1",
-        "laravel/framework": "^5.6||^6.0||^7.0||^8.0||^9.0",
+        "laravel/framework": "^5.6||^6.0||^7.0||^8.0||^9.0||^10.0",
         "divineomega/php-countries": "^2.1",
         "divineomega/php-postcodes": "^4.5",
         "langleyfoxall/simple-google-maps": "^1.0",


### PR DESCRIPTION
## Summary
- allow installation on Laravel 10
- document compatibility range in the README

## Testing
- `php -v` *(fails: command not found)*
- `composer validate --no-check-publish` *(fails: command not found)*